### PR TITLE
Whitepaper Link -> IPNS

### DIFF
--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -72,7 +72,7 @@ const Hero = ({  }) => {
                       </a>
                     </div>
                     <div class="mt-3 sm:mt-0 mx-3">
-                      <a href="http://ipfs.io/ipfs/QmNfXy5uCQjEWabnAsvJJPGkKNc6wSZu9M9w2cNxQ8WTo8" target="_blank" class="button text-center typeform-share block w-full py-4 px-8 rounded-md shadow kubelt-bg-blue text-white font-medium">
+                      <a href="https://ipfs.io/ipns/k51qzi5uqu5djd0aje0mf1l5zpxzu5y9vuhlgrjlna4ikj818tzwdxsby6y57x" target="_blank" class="button text-center typeform-share block w-full py-4 px-8 rounded-md shadow kubelt-bg-blue text-white font-medium">
                         Whitepaper
                       </a>
                     </div>


### PR DESCRIPTION
# Why

Link to the whitepaper via IPNS name so that, when published via GHA job, this link doesn't have to change. IPNS names are stable for underlying, mutable CIDs.

# What

* Move whitepaper to IPNS over ipfs.io gateway.
* Move HTTP to HTTPS